### PR TITLE
feat: driver name generator

### DIFF
--- a/cmd/name-gen/main.go
+++ b/cmd/name-gen/main.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/majori/wrc-laptimer/pkg/username"
+)
+
+func main() {
+	seed := os.Args[1]
+	fmt.Println(username.GenerateFromSeed(seed))
+}

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -4,6 +4,8 @@ import (
 	"database/sql"
 	"fmt"
 	"log/slog"
+
+	"github.com/majori/wrc-laptimer/pkg/username"
 )
 
 func (d *Database) ListenForUserLogins(cardEvents <-chan string) {
@@ -45,7 +47,7 @@ func (d *Database) ListenForUserLogins(cardEvents <-chan string) {
 }
 
 func (d *Database) CreateUser(id string) error {
-	name := id[:5] // TODO: Get a better placeholder name
+	name := username.GenerateFromSeed(id)
 	_, err := d.db.ExecContext(d.ctx, `
 		INSERT INTO users (id, name)
 		VALUES (?, ?)

--- a/pkg/username/username.go
+++ b/pkg/username/username.go
@@ -1,0 +1,133 @@
+package username
+
+import (
+	"hash/fnv"
+	"math/rand"
+)
+
+var adjective = []string{
+	"Ruosteinen",
+	"Bensanhajuinen",
+	"Dieselmäinen",
+	"Kireä",
+	"Taivaallinen",
+	"Mutainen",
+	"Pölyinen",
+	"Rämisevä",
+	"Legendaarinen",
+	"Tahmanen",
+	"Yliohjautuva",
+	"Aliohjautuva",
+	"Savuava",
+	"Öljyinen",
+	"Likainen",
+	"Kiiltävä",
+	"Ruosteeton",
+	"Kolhiintunut",
+	"Naarmuinen",
+	"Äänekäs",
+	"Tehokas",
+	"Voimakas",
+	"Nopea",
+	"Kevyt",
+	"Ketterä",
+	"Raskas",
+	"Kevyt",
+	"Virtaviivainen",
+	"Sporttinen",
+	"Klassinen",
+	"Vintage",
+	"Moderni",
+	"Retrohenkinen",
+	"Ahdettu",
+	"Virityskelpoinen",
+}
+
+var epithet = []string{
+	"Fullsend",
+	"Lintta",
+	"Kelirikko",
+	"Eri Nopee",
+	"Vaihdekeppi",
+	"V8",
+	"Dacia",
+	"Nahkapuku",
+	"Saabisti",
+	"Terminal damage",
+	"Sytytystulppa",
+	"Vale",
+	"Sierra",
+	"Neliveto",
+	"Erikoiskoe",
+	"Täyskaasu",
+	"Kaasujalka",
+	"Turboahdettu",
+	"Siirtymätaival",
+	"Apukuski",
+	"Maximum Attack",
+}
+
+var name = []string{
+	"Loeb",
+	"McRae",
+	"Tommi",
+	"Timo",
+	"Marcus",
+	"Kalle",
+	"Grönholm",
+	"Carlos",
+	"Solberg",
+	"Burns",
+	"Kankkunen",
+	"Vatanen",
+	"Väinö",
+	"Olavi",
+	"Kalevi",
+	"Paavo",
+	"Jorma",
+	"Stefa",
+	"Arvo",
+	"Reino",
+	"Aino",
+	"Helmi",
+	"Martta",
+	"Tyyne",
+	"Hilja",
+	"Ahti",
+	"Lempi",
+	"Lalli",
+	"Kyllikki",
+	"Aili",
+	"Saima",
+	"Ester",
+	"Hilma",
+	"Bertta",
+	"Lyyli",
+	"Hilda",
+	"Kerttu",
+	"Elsa",
+	"Sylvi",
+	"Hillervo",
+	"Eeva",
+	"Kaarina",
+	"Kirsti",
+	"Bensalenkkari",
+	"Bensalenkkar",
+	"Teuvo",
+	"Orvokki",
+	"Jallu",
+}
+
+func getFNVHash(s string) int64 {
+	h := fnv.New64a()
+	h.Write([]byte(s))
+	return int64(h.Sum64())
+}
+
+func GenerateFromSeed(seed string) string {
+	seededRand := rand.New(rand.NewSource(getFNVHash(seed)))
+	randomisedEpithet := adjective[seededRand.Intn(len(adjective))]
+	randomisedNickname := epithet[seededRand.Intn(len(epithet))]
+	randomisedName := name[seededRand.Intn(len(name))]
+	return randomisedEpithet + " " + randomisedNickname + " " + randomisedName
+}


### PR DESCRIPTION
I have no idea what I'm doing.

Added a function which generates default usernames whappuapp style. It is seeded, so that if database is emptied, the default name is still predictable making it (hopefully) easier for people to remember their nickname. Might be redundant, but added a 2nd entry point to run name gen locally. 